### PR TITLE
Move the labelTitle view into the animator.

### DIFF
--- a/PullToRefreshDemo/PacmanAnimator.swift
+++ b/PullToRefreshDemo/PacmanAnimator.swift
@@ -76,7 +76,7 @@ class PacmanAnimator: PullToRefreshViewAnimator {
         if layerLoader.superlayer == nil {
             superview.layer.addSublayer(layerLoader)
         }
-        let center = CGPoint(x: 30, y: superview.frame.size.height / 2)
+        let center = CGPoint(x: superview.bounds.midX, y: superview.bounds.midY)
         let bezierPathLoader = UIBezierPath(arcCenter: center, radius: CGFloat(10), startAngle: CGFloat(0), endAngle: CGFloat(2 * M_PI), clockwise: true)
         let bezierPathSeparator = UIBezierPath()
         bezierPathSeparator.moveToPoint(CGPointMake(0, superview.frame.height - 1))

--- a/Refresher/Animator.swift
+++ b/Refresher/Animator.swift
@@ -26,12 +26,29 @@ import QuartzCore
 import UIKit
 
 class Animator: PullToRefreshViewAnimator {
-    
-    private let layerLoader: CAShapeLayer = CAShapeLayer()
-    private let layerSeparator: CAShapeLayer = CAShapeLayer()
+
+    private var animating = false {
+        didSet {
+
+            configureLabelTitle()
+        }
+    }
+    private var progress: CGFloat = 0.0 {
+        didSet {
+
+            configureLabelTitle()
+        }
+    }
+
+    private let labelTitle = UILabel()
+    private let layerLoader = CAShapeLayer()
+    private let layerSeparator = CAShapeLayer()
     
     init() {
-    
+
+        labelTitle.textAlignment = .Center
+        labelTitle.autoresizingMask = .FlexibleLeftMargin | .FlexibleRightMargin
+
         layerLoader.lineWidth = 4
         layerLoader.strokeColor = UIColor(red: 0, green: 0.48, blue: 1, alpha: 1).CGColor
         layerLoader.strokeEnd = 0
@@ -39,8 +56,21 @@ class Animator: PullToRefreshViewAnimator {
         layerSeparator.lineWidth = 1
         layerSeparator.strokeColor = UIColor(red: 0.7, green: 0.7, blue: 0.7, alpha: 1).CGColor
     }
-    
+
+    func configureLabelTitle() {
+
+        if animating {
+            labelTitle.text = NSLocalizedString("Loading ...", comment: "Refresher")
+        } else if progress >= 1.0 {
+            labelTitle.text = NSLocalizedString("Release to refresh", comment: "Refresher")
+        } else {
+            labelTitle.text = NSLocalizedString("Pull to refresh", comment: "Refresher")
+        }
+    }
+
     func startAnimation() {
+
+        animating = true
         
         let pathAnimationEnd = CABasicAnimation(keyPath: "strokeEnd")
         pathAnimationEnd.duration = 0.5
@@ -60,12 +90,17 @@ class Animator: PullToRefreshViewAnimator {
     }
     
     func stopAnimation() {
-        
+
+        animating = false
         layerLoader.removeAllAnimations()
     }
     
     func layoutLayers(superview: UIView) {
-        
+
+        if labelTitle.superview == nil {
+          labelTitle.frame = superview.bounds
+          superview.addSubview(labelTitle)
+        }
         if layerLoader.superlayer == nil {
             superview.layer.addSublayer(layerLoader)
         }
@@ -85,7 +120,8 @@ class Animator: PullToRefreshViewAnimator {
     }
     
     func changeProgress(progress: CGFloat) {
-        
+
+        self.progress = progress
         layerLoader.strokeEnd = progress
     }
 }

--- a/Refresher/PullToRefreshView.swift
+++ b/Refresher/PullToRefreshView.swift
@@ -37,17 +37,15 @@ public protocol PullToRefreshViewAnimator {
 
 public class PullToRefreshView: UIView {
     
-    public let labelTitle = UILabel() // this maybe should be added in animator???
-
-    private var scrollViewBouncesDefaultValue: Bool = false
-    private var scrollViewInsetsDefaultValue: UIEdgeInsets = UIEdgeInsetsZero
+    private var scrollViewBouncesDefaultValue = false
+    private var scrollViewInsetsDefaultValue = UIEdgeInsetsZero
 
     private var animator: PullToRefreshViewAnimator = Animator()
     private var action: (() -> ()) = {}
 
     private var previousOffset: CGFloat = 0
 
-    internal var loading: Bool = false {
+    internal var loading = false {
         
         didSet {
             if loading {
@@ -78,12 +76,6 @@ public class PullToRefreshView: UIView {
         
         super.init(frame: frame)
         autoresizingMask = .FlexibleWidth
-        labelTitle.frame = bounds
-        labelTitle.textAlignment = .Center
-        labelTitle.autoresizingMask = .FlexibleLeftMargin | .FlexibleRightMargin
-        labelTitle.textColor = UIColor.blackColor()
-        labelTitle.text = NSLocalizedString("Pull to refresh", comment: "Refresher")
-        addSubview(labelTitle)
     }
     
     public required init(coder aDecoder: NSCoder) {
@@ -122,25 +114,16 @@ public class PullToRefreshView: UIView {
 
     public override func observeValueForKeyPath(keyPath: String, ofObject object: AnyObject, change: [NSObject: AnyObject], context: UnsafeMutablePointer<()>) {
         
-        if (context == &KVOContext) {
+        if context == &KVOContext {
             if let scrollView = superview as? UIScrollView where object as? NSObject == scrollView {
                 if keyPath == contentOffsetKeyPath {
                     var offsetWithoutInsets = previousOffset + scrollViewInsetsDefaultValue.top
-                    if (offsetWithoutInsets < -frame.size.height) {
-                        if (scrollView.dragging == false && loading == false) {
+                    if offsetWithoutInsets < -frame.size.height {
+                        if scrollView.dragging == false && loading == false {
                             loading = true
-                        } else if (loading == true) {
-                            labelTitle.text = NSLocalizedString("Loading ...", comment: "Refresher")
-                        } else {
-                            labelTitle.text = NSLocalizedString("Release to refresh", comment: "Refresher")
-                            animator.changeProgress(-offsetWithoutInsets / frame.size.height)
                         }
-                    } else if (loading == true) {
-                        labelTitle.text = NSLocalizedString("Loading ...", comment: "Refresher")
-                    } else if (offsetWithoutInsets < 0) {
-                        labelTitle.text = NSLocalizedString("Pull to refresh", comment: "Refresher")
-                        animator.changeProgress(-offsetWithoutInsets / frame.size.height)
                     }
+                    animator.changeProgress(-offsetWithoutInsets / frame.size.height)
                     previousOffset = scrollView.contentOffset.y
                 }
             }


### PR DESCRIPTION
This means that anybody who customizes the animator will have to handle this themselves, but I think that’s appropriate as each implementation of this is likely to involve custom branding.

This also makes `PacmanAnimator` put its graphic in the center since the label is no longer there.